### PR TITLE
Route type declaration

### DIFF
--- a/packages/http-router/index.d.ts
+++ b/packages/http-router/index.d.ts
@@ -6,6 +6,6 @@ interface Routes {
     handler: middy.MiddyfiedHandler;
 }
 
-declare function httpRouterHandler(routes: Routes[]): any;
+declare function httpRouterHandler(routes: Routes[]): middy.middlewarObj;
 
 export default httpRouterHandler;

--- a/packages/http-router/index.d.ts
+++ b/packages/http-router/index.d.ts
@@ -1,5 +1,11 @@
-// import middy from '@middy/core'
+import middy from '@middy/core';
 
-declare function httpRouterHandler (): any
+interface Routes {
+    method: string;
+    path: string;
+    handler: middy.MiddyfiedHandler;
+}
 
-export default httpRouterHandler
+declare function httpRouterHandler(routes: Routes[]): any;
+
+export default httpRouterHandler;

--- a/packages/http-router/index.d.ts
+++ b/packages/http-router/index.d.ts
@@ -6,6 +6,6 @@ interface Routes {
     handler: middy.MiddyfiedHandler;
 }
 
-declare function httpRouterHandler(routes: Routes[]): middy.middlewarObj;
+declare function httpRouterHandler(routes: Routes[]): middy.MiddlewareObj;
 
 export default httpRouterHandler;

--- a/packages/http-router/index.test-d.ts
+++ b/packages/http-router/index.test-d.ts
@@ -2,7 +2,7 @@ import middy from '@middy/core';
 import httpRouterHandler from '.';
 import { expectType } from 'tsd';
 
-const middleware = validator({
+const middleware = httpRouterHandler({
     method: 'GET',
     path: '/',
     handler: () => true

--- a/packages/http-router/index.test-d.ts
+++ b/packages/http-router/index.test-d.ts
@@ -1,6 +1,10 @@
-import { expectType } from 'tsd'
-// import middy from '@middy/core'
-import httpRouterHandler from '.'
+import middy from '@middy/core';
+import httpRouterHandler from '.';
+import { expectType } from 'tsd';
 
-const middleware = httpRouterHandler()
-expectType<any>(middleware)
+const middleware = validator({
+    method: 'GET',
+    path: '/',
+    handler: () => true
+});
+expectType<middy.MiddlewareObj>(middleware);


### PR DESCRIPTION
Hello,

Middleware package `@middy/http-router` has no input type defined for `httpRouterHandler`.

When attempting to use the HTTP Router middleware in Typescript, you receive an error `Expected 0 arguments, but got 1.ts(2554)`.

This PR adds a new `Route` interface for `httpRouterHandler`.